### PR TITLE
Support repo links with a trailing slash

### DIFF
--- a/Components/DownloadButton.jsx
+++ b/Components/DownloadButton.jsx
@@ -11,12 +11,12 @@ class DownloadButton extends React.Component {
       .replace(/(?:\n|<|>)/g, " ")
       .split(" ")
       .filter((f) =>
-        f.match(/^https?:\/\/(www.)?git(hub|lab).com\/[\w-]+\/[\w-]+/)
+        f.match(/^https?:\/\/(www.)?git(hub|lab).com\/[\w-]+\/[\w-]+\/?/)
       )[0];
     if (!GithubLink) return <></>;
-    const repoNameMatch = GithubLink.match(/[\w-]+$/);
+    const repoNameMatch = GithubLink.match(/([\w-]+)\/?$/);
     if (!repoNameMatch) return <></>;
-    const repoName = repoNameMatch[0];
+    const repoName = repoNameMatch[1];
     var installed = powercord.pluginManager.isInstalled(repoName);
     if (!this.props.message.content.includes("https://github.com")) {
       return (

--- a/downloadPlugin.js
+++ b/downloadPlugin.js
@@ -3,7 +3,7 @@ const { spawn } = require("child_process");
 const fs = require("fs");
 async function downloadPlugin(url, powercord) {
   const pluginDir = join(__dirname, "..");
-  const repoName = url.match(/[\w-]+$/)[0];
+  const repoName = url.match(/([\w-]+)\/?$/)[1];
   let status;
   let c;
   try {

--- a/index.js
+++ b/index.js
@@ -44,10 +44,10 @@ module.exports = class PowercordPluginDownloader extends Plugin {
     inject("PluginDownloader", mdl, "default", ([{ target }], res) => {
       if (!target || !target.href || !target.tagName) return res
       var match = target.href.match(
-        /^https?:\/\/(www.)?git(hub|lab).com\/[\w-]+\/[\w-]+/
+        /^https?:\/\/(www.)?git(hub|lab).com\/[\w-]+\/[\w-]+\/?/
       );
       if (target.tagName.toLowerCase() === "a" && match) {
-        var repoName = target.href.match(/[\w-]+$/)[0];
+        var repoName = target.href.match(/([\w-]+)\/?$/)[1];
         res.props.children.splice(
           4,
           0,


### PR DESCRIPTION
Repository links with a trailing slash do not have the option to Download Plugin