### PR TITLE
Make the beta plugin cards more unified with the Powercord plugin list ones.

### DIFF
--- a/Components/Store/Card.jsx
+++ b/Components/Store/Card.jsx
@@ -23,39 +23,39 @@ module.exports = class Card extends React.Component {
             return null
         } else {
             return (
-                <div className="PPD-StoreCard">
-                    <h1 className="PPD-CardTitle">
-                        <span>{repoName}</span>
-                        <Tooltip position="top" text="Go to repository">
-                            <Clickable className="redirect" onClick={() => { openExternal(GithubLink)}}>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-external-link">
-                                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-                                    <polyline points="15 3 21 3 21 9"/>
-                                    <line x1="10" y1="14" x2="21" y2="3"/>
-                                </svg>
-                            </Clickable>
-                        </Tooltip>
-                        <Button disabled={this.message.message.embeds.length <= 0 && this.message.message.attachments.length <= 0} onClick={() => openModal(() => React.createElement(Preview, {message: this.message.message}))}>Open preview</Button>
-                    </h1>
-
-                    <div className="PPD-Details">
-                        <div className="PPD-CardContent">
-                            <div className="PPD-CardDescription">
+                <div className="PPD-Card">
+                    <div className="powercord-product cardPrimary-1Hv-to card-3Qj_Yx">
+                        <h4 className="powercord-product-header">
+                            <span>{repoName}</span>
+                            <Tooltip position="top" text="Go to repository">
+                                <Clickable className="redirect" onClick={() => { openExternal(GithubLink)}}>
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-external-link">
+                                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                                        <polyline points="15 3 21 3 21 9"/>
+                                        <line x1="10" y1="14" x2="21" y2="3"/>
+                                    </svg>
+                                </Clickable>
+                            </Tooltip>
+                            <Button disabled={this.message.message.embeds.length <= 0 && this.message.message.attachments.length <= 0} onClick={() => openModal(() => React.createElement(Preview, {message: this.message.message}))}>Open preview</Button>
+                        </h4>
+                        <div className="divider-3573oO dividerDefault-3rvLe-"></div>
+                        <div className="powercord-product-details">
+                            <div className="description">
                                 <Tooltip position="top" text="Description">
                                     <Receipt height={24} width={24} />
                                 </Tooltip>
                                 <span>This is a description test of a plugin</span>
                             </div>
-
-                            <div className="PPD-Metadata">
-                                <div className="PPD-Author">
+    
+                            <div className="metadata">
+                                <div className="author">
                                     <Tooltip position="top" text="Author">
                                         <Person width={24} height={24} />
                                     </Tooltip>
                                     <span>{this.message.author?.nick || this.message.message.author.username}</span> 
-
+    
                                 </div>
-                                <div className="PPD-Version">
+                                <div className="version">
                                     <Tooltip position="top" text="Version">
                                         <Tag width={24} height={24} />
                                     </Tooltip>
@@ -63,22 +63,24 @@ module.exports = class Card extends React.Component {
                                 </div>
                             </div>
                         </div>
-                    </div>
-
-
-                    <div className="PPD-StoreCardFooter">
-                        <div className="PPD-StoreButtons">
-                            {this.state.installed ?
-                                <Button disabled color={Button.Colors.RED}>Already Installed</Button> :
-                                <Button onClick={() => {
-                                    if (this.state.installed) return;
-                                    DownloadPlugin(GithubLink, powercord);
-                                    this.setState({installed: true});
-                                }}>Install</Button>
-                            }
+    
+                        <div className="divider-3573oO dividerDefault-3rvLe-"></div>
+    
+    
+                        <div className="powercord-product-footer">
+                            <div className="buttons">
+                                {this.state.installed ?
+                                    <Button disabled color={Button.Colors.RED}>Already Installed</Button> :
+                                    <Button onClick={() => {
+                                        if (this.state.installed) return;
+                                        DownloadPlugin(GithubLink, powercord);
+                                        this.setState({installed: true});
+                                    }}>Install</Button>
+                                }
+                            </div>
                         </div>
+    
                     </div>
-
                 </div>
             )
         }

--- a/style.scss
+++ b/style.scss
@@ -26,8 +26,7 @@
 
 .PPD-Card .powercord-product {
     color: var(--text-normal);
-    width: 50%;
-    margin: 30px 0 20px 3%;
+    margin: 30px 3% 20px 3%;
     &-header {
         text-transform: capitalize;
         align-items: center;

--- a/style.scss
+++ b/style.scss
@@ -24,22 +24,16 @@
   }
 
 
-.PPD-StoreCard {
+.PPD-Card .powercord-product {
+    color: var(--text-normal);
     width: 50%;
-    background-color: var(--deprecated-card-bg);
-    padding: 20px;
-    border: 1px solid var(--background-tertiary);
-    border-radius: 5px;
     margin: 30px 0 20px 3%;
-    .PPD-CardTitle {
+    &-header {
         text-transform: capitalize;
-        color: var(--text-normal);
         align-items: center;
         display: flex;
         .redirect {
             transition: color 50ms ease;
-            color: var(--text-normal);
-            justify-content: center;
             display: flex;
             &:hover {
                 color: var(--text-muted);
@@ -55,52 +49,16 @@
             font-size: 20px;
         }
     }
-    .PPD-Details {
-        border-top: solid 1.5px var(--background-modifier-accent);
-        border-bottom: solid 1.5px var(--background-modifier-accent);
-        padding: 20px 0;
-        .PPD-Metadata {
-            margin-top: 20px;
-            display: flex;
-            div:not(:first-child){
-                margin: 0 25%;
-            }
-        }
-    }
-}
 
-
-
-.PPD-StoreCardFooter {
-    margin-top: 10px;
-    display: flex;
-}
-
-.PPD-StoreButtons {
-    margin-left: auto;
-}
-
-.PPD-Details {
-    color: var(--text-normal);
-    margin-top: 15px;
-    .PPD-CardDescription, .PPD-Metadata > div {
+    .metadata {
         display: flex;
-        align-items: center;
-
+        div:not(:first-child){
+            margin: 0;
+        }
         > div {
-            display: inline;
-            margin-right: 10px;
+            width: 33%;
         }
     }
-
-    .PPD-Metadata {
-        .PPD-Version span + div {
-            margin-left: 5px;
-            color: #faa61a;
-        }
-    }
-
-
 }
 
 .PPD-Preview {

--- a/style.scss
+++ b/style.scss
@@ -25,18 +25,16 @@
 
 
 .PPD-StoreCard {
-    width: 92.5%;
-    background-color: var(--background-secondary);
-    padding: 10px;
+    width: 50%;
+    background-color: var(--deprecated-card-bg);
+    padding: 20px;
+    border: 1px solid var(--background-tertiary);
     border-radius: 5px;
-    margin-left: 3%;
-    margin-top: 30px;
-    margin-bottom: 20px;
-    .PPD-CardTitle{
+    margin: 30px 0 20px 3%;
+    .PPD-CardTitle {
         text-transform: capitalize;
         color: var(--text-normal);
         align-items: center;
-        padding-top: 6px;
         display: flex;
         .redirect {
             transition: color 50ms ease;
@@ -52,20 +50,20 @@
         button {
             margin-left: auto;
         }
-        span{
+        span {
             margin-right: 10px;
             font-size: 20px;
         }
     }
-    .PPD-Details{
+    .PPD-Details {
         border-top: solid 1.5px var(--background-modifier-accent);
         border-bottom: solid 1.5px var(--background-modifier-accent);
         padding: 20px 0;
-        .PPD-Metadata{
+        .PPD-Metadata {
             margin-top: 20px;
             display: flex;
             div:not(:first-child){
-                margin: 0 30px;
+                margin: 0 25%;
             }
         }
     }


### PR DESCRIPTION
>Ok so, I just got some emails about the thread on the previous pr and saw your thoughts on it. I think this is a lot better and will maybe get merged into upstream.

This pr makes it so the beta plugin cards look better and more like (they use the classes the original ones use) the [powercord plugins list ones](https://github.com/powercord-org/powercord/blob/v2/src/Powercord/plugins/pc-moduleManager/components/parts/InstalledProduct.jsx). Here are two pictures demonstrating each one being in use as well as the one in the current master branch.

![New one](https://user-images.githubusercontent.com/41871089/135074253-4d182ff4-5c13-4b8e-9963-1a76c0c6db7c.png)
![Current one](https://user-images.githubusercontent.com/41871089/135075064-3f159a99-2d4c-4fd6-970b-174413758282.png)
![Plugins List](https://user-images.githubusercontent.com/41871089/135075145-f1037e2e-1543-4688-955c-f0b6d7516e57.png)

Hope this will get more positive feedback lol.