### PR TITLE
Make beta setting switch better

### DIFF
--- a/Components/Settings.jsx
+++ b/Components/Settings.jsx
@@ -9,11 +9,12 @@ module.exports = class Settings extends React.Component {
         return (
             <div>
                 <SwitchItem
-                    note='Enable beta features'
+                    note='This feature will completely change #plugin-links and is still being worked on.'
                     value={this.props.getSetting('beta', false)}
                     onChange={() => this.props.toggleSetting('beta')}
                 >
-                    Beta Features
+                    Plugin Cards
+                    <div className='PPD-Beta' >BETA</div>
                 </SwitchItem>
             </div>
         )

--- a/style.scss
+++ b/style.scss
@@ -67,3 +67,15 @@
         overflow-x: auto !important;
     }
 }
+
+.PPD-Beta {
+    display: inline-block;
+    background: #f04747;
+    color: #fff;
+    margin-left: 6px;
+    border-radius: 5px;
+    padding: 0 5px;
+    font-size: 10px;
+    line-height: 16px;
+    text-transform: uppercase;
+  }


### PR DESCRIPTION
I have answered "What happened to #plugin-links" enough times that I decide to do this. This PR makes the beta settings switch actually explain what the heck it does so that only the most idiotic of idiots will flip it and then ask me what happened to their #plugin-links.