### PR TITLE
Fix URL parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,15 +41,11 @@ module.exports = class Downloader extends Plugin {
 
             inject("PD-ContextMenu", mod, "default", ([{ target }], res) => {
                 if (!target || !target?.href || !target?.tagName) return res;
-                let match = target.href.match(
-                    /^https?:\/\/(www.)?git(hub).com\/[\w-]+\/[\w-]+\/?/
-                );
+                const parsedUrl = new URL(target.href);
+                const isGitHub = parsedUrl.hostname.split(".").slice(-2).join(".") === "github.com";
+                const [, username, reponame] = parsedUrl.pathname.split("/"),
 
-
-                if (target.tagName.toLowerCase() === "a" && match) {
-                    let [, username, reponame] = new URL(target.href).pathname.split("/");
-
-
+                if (target.tagName.toLowerCase() === "a" && isGitHub && username && reponame) {
                     get(`https://github.com/${username}/${reponame}/raw/HEAD/powercord_manifest.json`).then((r) => {
                         if (r?.statusCode === 302) {
                             res.props.children.splice(

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = class Downloader extends Plugin {
                 if (!target || !target?.href || !target?.tagName) return res;
                 const parsedUrl = new URL(target.href);
                 const isGitHub = parsedUrl.hostname.split(".").slice(-2).join(".") === "github.com";
-                const [, username, reponame] = parsedUrl.pathname.split("/"),
+                const [, username, reponame] = parsedUrl.pathname.split("/");
 
                 if (target.tagName.toLowerCase() === "a" && isGitHub && username && reponame) {
                     get(`https://github.com/${username}/${reponame}/raw/HEAD/powercord_manifest.json`).then((r) => {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = class Downloader extends Plugin {
 
 
                 if (target.tagName.toLowerCase() === "a" && match) {
-                    let [, username, reponame] = target.href.match(/[\w-]+\//gm);
+                    let [, username, reponame] = new URL(target.href).pathname.split("/");
 
 
                     get(`https://github.com/${username}/${reponame}/raw/HEAD/powercord_manifest.json`).then((r) => {

--- a/index.js
+++ b/index.js
@@ -40,12 +40,12 @@ module.exports = class Downloader extends Plugin {
             const menu = await getModule(["MenuItem"]);
 
             inject("PD-ContextMenu", mod, "default", ([{ target }], res) => {
-                if (!target || !target?.href || !target?.tagName) return res;
+                if (!target || !target?.href || !target?.tagName || target.tagName.toLowerCase() !== "a") return res;
                 const parsedUrl = new URL(target.href);
                 const isGitHub = parsedUrl.hostname.split(".").slice(-2).join(".") === "github.com";
                 const [, username, reponame] = parsedUrl.pathname.split("/");
 
-                if (target.tagName.toLowerCase() === "a" && isGitHub && username && reponame) {
+                if (isGitHub && username && reponame) {
                     get(`https://github.com/${username}/${reponame}/raw/HEAD/powercord_manifest.json`).then((r) => {
                         if (r?.statusCode === 302) {
                             res.props.children.splice(


### PR DESCRIPTION
The regex that was being used to extract the username and repo name was including trailing slashes on each (which would result in 404s for both manifest.json and powercord_manifest.json). I'm pretty sure this is why some people couldn't get the Install Plugin button in the context menu after the merge with Theme Downloader.

This fixes that issue by using `new URL(target.href)` and splitting its hostname and pathname properties, rather than testing regexes against target.href directly. This approach should provide more reliable results in case any characters not matched by the old regex, namely periods, are part of the username or repo name. Adding back support for GitLab should be fairly trivial. (Incidentally, it appears from my very limited testing that GitLab supports the same raw content URL format as GitHub, so it should be a matter of just plugging the domain that's extracted earlier in the function into the request URLs.)